### PR TITLE
[ fix ] indexOutOfBound for trimVersion

### DIFF
--- a/src/org/ice1000/tt/project/ui/ui-impl.kt
+++ b/src/org/ice1000/tt/project/ui/ui-impl.kt
@@ -28,7 +28,7 @@ abstract class VersionedExecutableProjectConfigurableImpl : VersionedExecutableP
 
 	init {
 		exePathField.addPropertyChangeListener {
-			versionLabel.text = trimVersion(versionOf(exePathField.text))
+			versionLabel.text = versionOf(exePathField.text)?.let { trimVersion(it) }.orEmpty()
 		}
 	}
 

--- a/src/org/ice1000/tt/utils.kt
+++ b/src/org/ice1000/tt/utils.kt
@@ -28,7 +28,7 @@ fun validateExe(exePath: String) = try {
 
 fun versionOf(exePath: String) = executeCommand("$exePath --version")
 	.first
-	.firstOrNull().orEmpty()
+	.firstOrNull()
 
 inline fun executeCommandToFindPath(command: String, validate: (String) -> Boolean = ::validateExe) =
 	executeCommand(command, null, 500L)


### PR DESCRIPTION
Reproduce:
Go to `Preferences | Languages & Frameworks | Mini-TT` without having proper mini-tt exe path. Same thing with Agda, Narc, and Voile.
Reason:
`versionOf` can return empty string, upon which we call `substring`: 
```json
"trimVersion": "version.substring(\"minittc\".length()).trim()"
```